### PR TITLE
配置仓库修改为github，增加配置项，现在可以成功从github取到配置

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,13 @@
-
 spring:
   cloud:
     config:
       server:
         git:
-          uri: https://github.com/tsuixh/config-server/tree/dev/config
+          uri: https://github.com/tsuixh/config-server
+          search-paths: config
+          username: githubaccount
+          password: githubpassword
+          default-label: master
   application:
     name: config-server
 server:


### PR DESCRIPTION
讲连接github仓库的功能合并到master